### PR TITLE
recipe: remove xdg-desktop-portal-gnome

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -89,3 +89,4 @@ flatpaks:
   - com.spotify.Client
   - com.protonvpn.www
   - org.onlyoffice.desktopeditors
+  - xdg-desktop-portal-gnome


### PR DESCRIPTION
xdg-desktop-portal-gnome is incompatible with xdg-desktop-portal-hyprland so it must be removed